### PR TITLE
Fixed broken dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ h5py==3.8.0
 idna==3.4
 importlib-metadata==6.6.0
 importlib-resources==5.12.0
-install==1.3.5
+
 jax==0.4.8
 joblib==1.2.0
 keras==2.12.0
@@ -29,7 +29,7 @@ libclang==16.0.0
 Markdown==3.4.3
 MarkupSafe==2.1.2
 matplotlib==3.7.1
-mediapipe==0.9.1.0
+mediapipe
 ml-dtypes==0.1.0
 numpy==1.23.5
 oauthlib==3.2.2
@@ -57,7 +57,7 @@ tensorboard-data-server==0.7.0
 tensorflow==2.12.0
 tensorflow-addons==0.20.0
 tensorflow-estimator==2.12.0
-tensorflow-io-gcs-filesystem==0.32.0
+
 termcolor==2.3.0
 tf-utils @ git+https://github.com/hoyso48/tf-utils@d9bf287e8284d1779e61b9a3ff13a14141e00a59
 threadpoolctl==3.1.0
@@ -69,4 +69,4 @@ urllib3==2.0.2
 Werkzeug==2.3.4
 wrapt==1.14.1
 zipp==3.15.0
-pillow>=10.0.1
+


### PR DESCRIPTION
Fixes for requirements.txt Installation Errors    : - 

Hello ! I was setting up this project locally and ran into a few fatal pip install errors. I've updated the requirements.txt to fix them so future users can install the environment smoothly .

Changes made : - 

-  Removed install==1.3.5 (Phantom package that cancels the entire pip installation)

-  Removed the mediapipe==0.9.1.0 version constraint (This specific older version is no longer found by pip on modern Python/Windows setups).

-  Removed tensorflow-io-gcs-filesystem==0.32.0 (Causes version conflicts and isn't required for local webcam inference)

-  Removed the duplicate pillow entry at the bottom of the file.

 - Everything installs and runs perfectly after these tweaks! Let me know if you need me to adjust anything